### PR TITLE
Add RHEL7 spec file

### DIFF
--- a/RHEL7/slurm-web.spec
+++ b/RHEL7/slurm-web.spec
@@ -42,8 +42,6 @@ Requires:   python-pyslurm
 The role of the API is to serve raw runtime data about a system (typically a supercomputer) running Slurm. All data are delivered in common and standard JSON format. This backend API is developed in Python programming language.
 
 %prep
-tar -xvf $RPM_SOURCE_DIR/slurm-web.tar.gz
-cd slurm-web
 
 %build
 

--- a/RHEL7/slurm-web.spec
+++ b/RHEL7/slurm-web.spec
@@ -1,0 +1,109 @@
+# Turn off the Fascist build policy (ignore unused files)
+%define _unpackaged_files_terminate_build 0 
+
+Name:           Slurm-web
+Version:        1.1.3
+Release:        1%{?dist}
+Summary:        Slurm-web is web application that serves as web frontend to Slurm workload manager.
+
+License:        GPLv2+
+URL:            http://edf-hpc.github.io/slurm-web/
+Source0:        https://github.com/edf-hpc/slurm-web
+
+BuildArch:      noarch
+Requires:       slurm-web-dashboard
+Requires:       slurm-web-restapi
+
+%description
+Slurm-web is web application that serves as web frontend to Slurm workload manager.
+
+%package -n slurm-web-dashboard
+Summary:    Slurm-web interface
+BuildArch:  noarch
+Requires:   libjs-bootstrap
+Requires:   js-jquery
+Requires:   libjs-jquery-flot
+Requires:   httpd
+Requires:   httpd-devel
+
+%description -n slurm-web-dashboard
+The role of the dashboard is to show to users, administrators and decidors all supercomputer runtime data in a graphical and attractive way. It is a web GUI that aims to be user-friendly, beautiful and clean. The dashboard is developed in HTML and Javascript. It is designed to be used with any modern web browser with fairly decent support of HTML5, Javascript and CSS.
+
+%package -n slurm-web-restapi
+Summary:    Slurm-web backend api
+BuildArch:  noarch
+Requires:   python
+Requires:   clustershell
+#Requires:   python-clustershell
+Requires:   python-flask
+Requires:   python-pyslurm
+
+%description -n slurm-web-restapi
+The role of the API is to serve raw runtime data about a system (typically a supercomputer) running Slurm. All data are delivered in common and standard JSON format. This backend API is developed in Python programming language.
+
+%prep
+tar -xvf $RPM_SOURCE_DIR/slurm-web.tar.gz
+cd slurm-web
+
+%build
+
+%install
+
+# Install apache conf files
+mkdir -p $RPM_BUILD_ROOT/etc/httpd/conf.d
+install -m 644 slurm-web/conf/slurm-web-dashboard.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/slurm-web-dashboard.conf
+install -m 644 slurm-web/conf/slurm-web-restapi.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/slurm-web-restapi.conf 
+
+# Install racks configuration file
+mkdir -p $RPM_BUILD_ROOT/etc/slurm-web
+install -m 644 slurm-web/conf/racks.xml $RPM_BUILD_ROOT/etc/slurm-web/racks.xml
+
+# Install remaining dashboard files
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard/css
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard/static
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard/js
+install -m 644 slurm-web/html/index.html $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard/index.html
+install -m 644 slurm-web/css/dashboard.css $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard/css/dashboard.css
+install -m 644 slurm-web/static/logo.png $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard/static/logo.png
+install -m 644 slurm-web/js/slurm-dashboard.js $RPM_BUILD_ROOT/usr/share/slurm-web/dashboard/js/slurm-dashboard.js
+
+# Install remaining restapi files 
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web/restapi
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web/restapi/schema
+mkdir -p $RPM_BUILD_ROOT/usr/share/slurm-web/restapi/schema/dtd
+install -m 644 slurm-web/rest/slurmrestapi.py $RPM_BUILD_ROOT/usr/share/slurm-web/restapi/slurm-web-restapi.wsgi
+install -m 644 slurm-web/rest/slurmrestapi.py $RPM_BUILD_ROOT/usr/share/slurm-web/restapi/slurmrestapi.py
+install -m 644 slurm-web/schema/racks.dtd $RPM_BUILD_ROOT/usr/share/slurm-web/restapi/schema/dtd/racks.dtd
+
+# Install doc files
+install -m 644 slurm-web/README.md $RPM_BUILD_ROOT/usr/share/slurm-web/README.md
+install -m 644 slurm-web/COPYING $RPM_BUILD_ROOT/usr/share/slurm-web/COPYING
+
+# start apache server if not already started, otherwise restart
+systemctl restart httpd
+
+#start flask app
+#python $RPM_BUILD_ROOT/usr/share/slurm-web/restapi/slurmrestapi.py
+
+%files
+%doc /usr/share/slurm-web/README.md
+%doc /usr/share/slurm-web/COPYING
+
+%files -n slurm-web-dashboard
+/etc/httpd/conf.d/slurm-web-dashboard.conf 
+/usr/share/slurm-web/dashboard/css/dashboard.css 
+/usr/share/slurm-web/dashboard/static/logo.png 
+/usr/share/slurm-web/dashboard/js/slurm-dashboard.js 
+/usr/share/slurm-web/dashboard/index.html
+
+%files -n slurm-web-restapi
+/etc/slurm-web/racks.xml 
+/etc/httpd/conf.d/slurm-web-restapi.conf 
+/usr/share/slurm-web/restapi/slurm-web-restapi.wsgi 
+/usr/share/slurm-web/restapi/slurmrestapi.py 
+/usr/share/slurm-web/restapi/schema/dtd/racks.dtd
+
+%changelog


### PR DESCRIPTION
I've managed to get slurm-web running on RHEL7. For the moment it takes a bit of work to get it running. Hopefully future releases can fix this. Perhaps this should be in a separate branch instead of creating a new directory? I'm not sure if a adding a new directory will break the debian build or not.

I've run into some problems and would appreciate someone with RHEL and rpm knowledge to look over/fix things:
1. Many of the required packages aren't in the yum rpm database (pyslurm, jquery-flot, bootstrap). Thus even after they're installed, yum still doesn't recognize them. As they are in the required package section, the only way to build is with the rpm --nodeps option. Is there a good way to list a required package not in the rpm database? For now installing with the --nodeps option works.
2. SElinux on RHEL7 prevents apache from accessing files it needs (like jquery, SLURM shared objects, and a few others). Ideally, an SElinux policy to fix this would somehow be installed with slurm-web. I'm not sure how to go about this as the files SElinex blocks could be in different places. For now, SElinux either needs to be disabled or a custom policy needs to be built.
3. For whatever reason I can't get the rpm to build without both a tar.gz and an uncompressed version of slurm-web in the SOURCES directory. Perhaps someone knows how to fix this?
4. Rpms typically have a format of name-version-release.architecture.rpm.  For this reason packages with a "-" are frowned upon. Perhaps rename slurm-web to SlurmWeb or slurm_web? I suppose only the rpm needs be renamed. 
5. Ideally you could just "rpm -ivh slurm-web.rpm" and the whole thing would install. Currently you have to do three separate "rpm -ivh" commands (See install instructions below). How do you install the whole package with one command? 

Install instructions:
1. Install dependencies <a href="http://edf-hpc.github.io/slurm-web/installation.html"> listed here </a>
2. <a href="http://wiki.centos.org/HowTos/SetupRpmBuildEnvironment"> Create an rpm build environment </a> 
3. Copy the spec file to the SPECS directory
4. Copy the slurm-web directory to the SOURCES directory
5. Create a tar.gz in the SOURCES directory as well
    your directory structure should look like:
/rpmbuild/
----SPECS/
--------slurm-web.spec
----SOURCES/
--------slurm-web
--------slurm-web.tar.gz
----RPMS/
----SRPMS/
----BUILD/
----BUILDROOT/
6. in the SPECS directory, build the rpms:
        $rpmbuild -ba slurm-web.spec
7. Install the rpms (they will have a version in the name like slurm-web-restapi-1.1.3-1.el7.noarch.rpm)
        $rpm -ivh --nodeps slurm-web-restapi
        $rpm -ivh --nodeps slurm-web-dashboard
        $rpm -ivh --nodeps slurm-web
8. Configure apache and disable SElinux (or make a custom policy)
