### PR TITLE
Add jobs and reservations privacy settings

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -91,3 +91,9 @@ You can set in this section:
 - *base* : the database where users have to be searched
 - *ugroup* : the LDAP group which the users are members
 - *expiration* : the TTL of the generated token
+
+Slurm-web also takes into account of the Private data parameter from
+`Slurm <https://slurm.schedmd.com/slurm.conf.html>`_. So far, only the Jobs
+View and Reservations View in Slurm-web are concerned by Private Data
+parameter. This feature prevents regular users and guests from seeing others'
+jobs or reservations if defined.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -397,6 +397,13 @@ guest button is added under the login form in the dashboard. The guests users
 have the *all* role. Then the *all* role must be enabled as well to allow the
 guests users to access the REST API.
 
+Besides the restriction of fields, it is also possible to add restrictions on
+jobs or reservations according to one's roles. This restriction can be set by
+Private Data from `Slurm <https://slurm.schedmd.com/slurm.conf.html>`_. If
+``jobs`` or ``reservations`` are defined previously in Slurm, non-admin users
+will not see nobody but their own jobs or reservations. The Jobs View or
+Reservations View will be empty if logging as ``guests``.
+
 Cache
 """""
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -160,6 +160,12 @@ You can close this box by clicking on the *Close* button:
 
 .. figure:: img/screenshot_job_close_details.*
 
+The Jobs view now takes Slurm's Private Data parameter into account. The
+description can be found in `Slurm <https://slurm.schedmd.com/slurm.conf.html>`_.
+If ``jobs`` has been defined previously in Slurm configuration, regular users
+can only see their own jobs whereas the superusers see all the jobs and guests
+can see none.
+
 Racks view
 ----------
 
@@ -197,7 +203,8 @@ rectangle. If a core is allocated to a job, the core is colored with a color
 depending on the job ID. All cores allocated to a job have the same color.
 However, note that due to limited number of colors, when there are a lot of
 running jobs, 2 cores allocated to 2 different jobs could potentially have the
-same color.
+same color. With Private Date set for ``jobs``, only current-user-related jobs
+will be shown for regular users.
 
 Again, a small legendary in a frame at the top right corner gives a recap of
 these information.
@@ -215,7 +222,8 @@ This view shows a representation in three dimensions of the HPC, according to
 how it is defined in the ``racks.xml`` file.
 
 As on the JobsMap view, it gives the activity on each core, showing the color
-of the current processed job.
+of the current processed job. Same effect of viewing restriction as JobsMap
+view with Private Data ``jobs`` parameter is defined.
 
 You can choose between 3 ways of visualization:
 
@@ -294,6 +302,12 @@ The table is composed of one row per reservation and 5 columns:
 #. The start time of this reservation
 #. The end time of this reservation
 
+This view, like Jobs View, can be applied with Slurm's Private Data as well.
+If ``reservations`` has been defined previously in
+`Slurm <https://slurm.schedmd.com/slurm.conf.html>`_ configuration, regular
+users are prevented from viewing others' reservations. Only admins are
+allowed to consult all the reservations.
+
 Gantt view
 ----------
 
@@ -306,6 +320,9 @@ informations in a modal.
 .. figure:: img/screenshot_ganntt_view_nodes.*
 
 .. figure:: img/screenshot_ganntt_view_qos.*
+
+Only jobs of current user will be evaluated for regular users if ``jobs``
+has been defined in Private Data configuration.
 
 Topology view
 -------------

--- a/rest/slurmrestapi.py
+++ b/rest/slurmrestapi.py
@@ -40,7 +40,8 @@ from settings import settings
 # for authentication
 from auth import (User, authentication_verify,
                   AuthenticationError, AllUnauthorizedError,
-                  guests_allowed, auth_enabled, fill_job_user)
+                  guests_allowed, auth_enabled, fill_job_user,
+                  get_current_user)
 
 from cache import get_from_cache
 
@@ -130,7 +131,7 @@ def get_jobs():
             jobs[jobid]["nodeset"] = list(
                 NodeSet(job["nodes"].encode('ascii', 'ignore'))
             )
-    return jobs
+    return filter_entities('jobs', jobs)
 
 
 @app.route('/job/<int:job_id>', methods=['GET', 'OPTIONS'])
@@ -141,7 +142,18 @@ def show_job(job_id):
 
     # pyslurm >= 16.05 expects a string in parameter of job.find_id()
     job = get_from_cache(pyslurm.job.find_id, 'show_job', str(job_id))
+    onlyUsersJobs = False
     fill_job_user(job)
+    if auth_enabled:
+        # If auth_enabled is true, getting the current user becomes
+        # possible because authentification_verify decorator has been
+        # already checked.
+
+        currentUser = get_current_user()
+        onlyUsersJobs = check_private_data_for_entity(currentUser, 'jobs')
+
+    if (onlyUsersJobs and job['login'] != currentUser.login):
+        raise AllUnauthorizedError
 
     return job
 
@@ -198,7 +210,7 @@ def get_reservations():
 
     reservations = get_from_cache(
         pyslurm.reservation().get, 'get_reservations')
-    return reservations
+    return filter_entities('reservations', reservations)
 
 
 @app.route('/partitions', methods=['GET', 'OPTIONS'])
@@ -493,6 +505,52 @@ def proxy():
     return render_template('proxy.html',
                            url_root=request.url_root,
                            masters=masters)
+
+
+def check_private_data_for_entity(user, entity):
+    """
+    Return true if the entity is one of the attribute defined previously in
+    Private Data settings.
+    """
+    onlyUsersEntities = False
+
+    if auth_enabled:
+        # Fetch the attributs of private_data
+        config = pyslurm.config().get()
+        private_data = config["private_data_list"]
+
+        if (private_data and entity in private_data and
+                user.role != 'admin'):
+            onlyUsersEntities = True
+    return onlyUsersEntities
+
+
+def filter_entities(entity, entitiesList):
+    """
+    Return the list entities filtered if privateData is on for the entities.
+    """
+    onlyUsersEntities = False
+    if auth_enabled:
+        # If auth_enabled is true, getting the current user becomes
+        # possible because authentification_verify decorator has been
+        # already checked.
+        currentUser = get_current_user()
+        onlyUsersEntities = check_private_data_for_entity(
+            currentUser, entity)
+
+    if onlyUsersEntities:
+        # if private data is applied and the entities' owner is different from
+        # current user, then the entities will not be added to the list to
+        # show if auth disabled, onlyUsersEntities becomes always False and all
+        # the entities are added to the list to show
+
+        return dict((k, v) for k, v in entitiesList.iteritems()
+                    if ((entity == 'reservations' and currentUser.login in
+                        v['users']) or (entity == 'jobs' and
+                        currentUser.login == v['login'])))
+
+    return entitiesList
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/tests/mocks/pyslurm.py
+++ b/tests/mocks/pyslurm.py
@@ -821,10 +821,17 @@ class SlurmCtld(object):
         self.qos = set()
         self.reservations = set()
         self.topology = set()
+        # Add private_data to mock config()
+        self.private_data = set()
+        self.private_data_list = set()
 
     @property
     def config(self):
-        return { 'cluster_name': self.cluster.name }
+        return {
+            u'cluster_name': self.cluster.name,
+            # Add private_data to mock config()
+            u'private_data': self.private_data,
+            u'private_data_list': self.private_data_list}
 
     def find_node(self, nodename):
         for node in self.nodes:

--- a/tests/setups/jupiter.py
+++ b/tests/setups/jupiter.py
@@ -89,6 +89,8 @@ def setup_cluster():
     setup.userbase.add(User('thomas', 'curie', 'toto', []))
 
     setup.ctld = SlurmCtld(name)
+    setup.ctld.private_data = 0
+    setup.ctld.private_data_list = []
     nodeset = NodeSet('cn[001-240]')
 
     for nodename in nodeset:

--- a/tests/setups/saturne.py
+++ b/tests/setups/saturne.py
@@ -70,10 +70,14 @@ def setup_cluster():
     setup.racks.add_nodeset(rack, 'cn[01-20]', 'nodetype1', '0', '2')
 
     setup.userbase = UserBase()
-    setup.userbase.add(User('pierre', 'curie', 'toto', ['user','admin']))
-    setup.userbase.add(User('marie', 'curie', 'toto', ['user','admin']))
+    setup.userbase.add(User('pierre', 'curie', 'toto', ['user', 'admin']))
+    # define mcurie as regular user to test private_data
+    setup.userbase.add(User('marie', 'curie', 'toto', ['user']))
 
     setup.ctld = SlurmCtld(name)
+    # Set private_data configuration
+    setup.ctld.private_data = 73
+    setup.ctld.private_data_list = ['jobs', 'usage', 'reservations']
     for nodeid in range(1, 30):
         nodename = u"cn%02d" % (nodeid)
         node = SlurmNode(nodename)
@@ -109,6 +113,26 @@ def setup_cluster():
     job.user_id = setup.userbase[0].uid
     job.account = 'physic'
     job.shared = 2^16 - 2
+    job.work_dir = u'/home/pierre'
+    job.command = u'/home/pierre/sleep.sh'
+    job.partition = partition.name
+    setup.ctld.jobs.add(job)
+
+    # Add another job from  diffrent user to test private_data
+    job = SlurmJob('2235')
+    job.name = 'test.sh'
+    job.qos = xqos.name
+    job.job_state = 'RUNNING'
+    job.nodes = 'cn03'
+    job.num_nodes = 1
+    job.num_cpus = 1
+    job.start_time = int(time.time() - 10)
+    job.time_limit = 3600
+    job.cpus_allocated = {'cn3': 1}
+    job.group_id = setup.userbase[1].gid
+    job.user_id = setup.userbase[1].uid
+    job.account = 'physic'
+    job.shared = 2 ^ 16 - 2
     job.work_dir = u'/home/pierre'
     job.command = u'/home/pierre/sleep.sh'
     job.partition = partition.name


### PR DESCRIPTION
The "PrivateData" parameter from Slurm configuration is now partially introduced to slurm-web. However, this change is only compatible with a modified version of pyslurm that contains an extra output (see https://github.com/edf-hpc/pyslurm/commit/634ed6948153aeee341a7a43d76d6e0fa94cde1e). Also, the mocks for testing are modified along with.

Jobs and Reservations views are affected in this change. Regular users may only see their own jobs or reservations if defined in PrivateData previously.