### PR TITLE
Fix global logout problem

### DIFF
--- a/dashboard/js/core/index.js
+++ b/dashboard/js/core/index.js
@@ -157,7 +157,7 @@ require([
     $(document).trigger('show', { page: config.STARTPAGE });
   });
 
-  $(document).on('logout', function(e) {
+  $(document).on('logout', function(e, onlyCurrentCluster) {
     var cluster;
 
     e.preventDefault();
@@ -167,14 +167,14 @@ require([
       user.removeUser(cluster);
     }
 
-    if (config.AUTOLOGIN) {
+    if (!config.AUTOLOGIN || onlyCurrentCluster) {
+      // clear authentication on current cluster
+      logout(config.cluster);
+    } else {
       // clear authentication on all clusters
       for (cluster in window.clusters) {
         logout(window.clusters[cluster]);
       }
-    } else {
-      // clear authentication on current cluster
-      logout(config.cluster);
     }
 
     $(document).trigger('show', { page: config.cluster.authentication.enabled ? 'login' : config.STARTPAGE });

--- a/dashboard/js/utils/ajax.js
+++ b/dashboard/js/utils/ajax.js
@@ -30,7 +30,8 @@ define([
     // /login route since this error in handled with login form logic in
     // dashboard/js/core/login/login.js
     if (jqueryXHR.status === 403 && !(error.url.indexOf('/login') > -1)) {
-      $(document).trigger('logout');
+      //add parameter to specify which cluster to logout whether autologin is true
+      $(document).trigger('logout', true);
     }
 
     // Ignore error for /cluster here because this route is used to


### PR DESCRIPTION
Avoid global logout while trying to access a failed cluster.
This problem occurs when autologin is on in configuration.