### PR TITLE
Add Docker support

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -69,6 +69,54 @@ From source
 
 Not supported yet. Please contact us if you want to improve this part.
 
+Docker
+^^^^^^
+
+To build Slurm-web as a Docker container, you will need to:
+ 
+1. Clone the git repository
+"""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+   $ git clone https://github.com/edf-hpc/slurm-web.git
+   $ cd slurm-web
+
+2. Build the image
+""""""""""""""""""
+
+.. code-block:: bash
+
+    $ cd docker/container
+    $ docker build -t slurm-web .
+    $ cd ../..
+
+3. Customize the configuration files 
+""""""""""""""""""""""""""""""""""""
+
+The container will use configuration files stored in a `conf/` directory (you can customize the path in the `run.sh` script). You can copy the provided `run.sh` script and examples in a location of your choice, and start from there:
+
+.. code-block:: bash
+
+   $ WORKDIR=$HOME/slurm-web
+   $ mkdir $WORKDIR
+   $ cp docker/run/run.sh $WORKDIR/
+   $ cp -R conf/ $WORKDIR/
+   $ cd $WORKDIR
+   ... edit configuration files ...
+
+4. Run the container
+""""""""""""""""""""
+
+You may want to edit the `run.sh` script to specify where you stored your configuration files
+
+.. code-block:: bash
+
+    $ cd $WORKDIR
+    $ ./run.sh
+
+You can then check that the container is running with `docker ps`, and the access the Slurm-web interface my pointing your browser to http://localhost:8081/slurm
+
 Distributions
 ^^^^^^^^^^^^^
 

--- a/docker/container/Dockerfile
+++ b/docker/container/Dockerfile
@@ -1,0 +1,109 @@
+# Use phusion/baseimage as base image. To make your builds reproducible, make
+# sure you lock down to a specific version, not to `latest`!
+# See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md for
+# a list of version numbers.
+FROM phusion/baseimage:0.9.19
+MAINTAINER Kilian Cavalotti <kilian@stanford.edu>
+
+# Set correct environment variables.
+ENV HOME /root
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Use baseimage-docker's init system
+CMD ["/sbin/my_init"]
+
+# Install locales
+RUN locale-gen en_US.UTF-8
+
+ENV BUILD_DEPS="git devscripts equivs apt-utils apache2-dev libslurm-dev python-setuptools cython python-dev libslurmdb-dev libslurm-dev ca-certificates"
+
+ENV RUN_DEPS="apache2 libapache2-mod-wsgi javascript-common python-flask clustershell libjs-bootstrap libjs-jquery-flot libjs-jquery-tablesorter munge slurm-llnl node-uglify fonts-dejavu-core python-ldap python-redis libjs-requirejs libjs-requirejs-text libjs-three libjs-d3 libjs-handlebars"
+
+# Enable universe and multiverse
+#RUN cat /etc/apt/sources.list && \
+#    sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list && \
+#    sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list
+
+# Install system dependencies
+RUN apt-get update -q && \
+    apt-get -y install $BUILD_DEPS $RUN_DEPS && \
+    ln -s /usr/lib/x86_64-linux-gnu/ /usr/lib64
+
+RUN a2enmod wsgi && \
+    a2enconf javascript-common
+
+# Build and install specific deps
+ENV SLURM_VER=15.08.2
+RUN cd /usr/src && \
+    git clone https://github.com/PySlurm/pyslurm.git && \
+    cd pyslurm && \
+    git checkout remotes/origin/$SLURM_VER && \
+    sed -i 's/__max_slurm_hex_version__ = "0x0f0803"/__max_slurm_hex_version__ = "0x0f0807"/' setup.py && \
+    tar cvfj ../python-pyslurm_$SLURM_VER.orig.tar.bz2 --exclude .git . && \
+    mk-build-deps -ri -t "apt-get -y --no-install-recommends" && \
+    dch -v $SLURM_VER-1 -D testing "New upstream release" && \
+    debuild -us -uc && \
+    dpkg -i ../python-pyslurm_$SLURM_VER-1_amd64.deb 
+
+RUN cd /usr/src && \
+    git clone https://github.com/edf-hpc/opentypejs.git && \
+    cd opentypejs && \
+    git checkout debian/0.4.3-2 && \
+	tar cvfj ../opentypejs_0.4.3.orig.tar.bz2 --exclude .git . && \
+	mk-build-deps -ri -t "apt-get -y --no-install-recommends" && \
+	debuild -us -uc && \
+	dpkg -i ../node-opentypejs_0.4.3-2_all.deb
+
+RUN cd /usr/src && \
+	git clone https://github.com/edf-hpc/libjs-bootstrap-typeahead.git && \
+	cd libjs-bootstrap-typeahead/ && \
+    git checkout debian/0.11.1-1 && \
+	tar cvfj ../libjs-bootstrap-typeahead_0.11.1.orig.tar.bz2 --exclude .git . && \
+	debuild -us -uc && \ 
+	dpkg -i ../libjs-bootstrap-typeahead_0.11.1-1_all.deb
+
+RUN cd /usr/src && \
+	git clone https://github.com/edf-hpc/libjs-bootstrap-tagsinput.git && \
+	cd libjs-bootstrap-tagsinput/ && \
+    git checkout debian/0.8.0-1 && \
+	tar cvfj ../libjs-bootstrap-tagsinput_0.8.0.orig.tar.bz2 --exclude .git . && \
+	debuild -us -uc && \
+	dpkg -i ../libjs-bootstrap-tagsinput_0.8.0-1_all.deb
+
+
+RUN cd /usr/src && \
+    git clone https://github.com/edf-hpc/slurm-web.git && \
+    cd slurm-web && \
+    git checkout debian/2.0.0 && \
+    debuild -us -uc && \
+    dpkg -i ../slurm-web-*deb 
+
+# Create apache2 service file and start it
+RUN rm /etc/apache2/sites-available/default-ssl.conf && \
+    echo www-data > /etc/container_environment/APACHE_RUN_USER && \
+    echo www-data > /etc/container_environment/APACHE_RUN_GROUP && \
+    echo /var/log/apache2 > /etc/container_environment/APACHE_LOG_DIR && \
+    echo /var/lock/apache2 > /etc/container_environment/APACHE_LOCK_DIR && \
+    echo /var/run/apache2.pid > /etc/container_environment/APACHE_PID_FILE && \
+    echo /var/run/apache2 > /etc/container_environment/APACHE_RUN_DIR && \
+    chown -R www-data:www-data /var/log/apache2 
+RUN mkdir -p /etc/service/apache2
+COPY apache2.sh /etc/service/apache2/run
+RUN chmod +x /etc/service/apache2/run
+
+# Create munge service file and start it
+RUN chown munge: /var/log/munge /var/lib/munge && \
+    mkdir -p /etc/service/munge
+COPY munge.sh /etc/service/munge/run
+RUN chmod +x /etc/service/munge/run
+
+
+# Cleanup
+RUN apt-get clean
+
+EXPOSE 80/tcp
+
+VOLUME ["/etc/slurm-web"]

--- a/docker/container/apache2.sh
+++ b/docker/container/apache2.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec /usr/sbin/apache2 -D FOREGROUND

--- a/docker/container/munge.sh
+++ b/docker/container/munge.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+mkdir -p /var/run/munge
+chown munge: /var/{log,lib,run}/munge
+exec /sbin/setuser munge /usr/sbin/munged 

--- a/docker/run/run.sh
+++ b/docker/run/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# EDIT: indicate where your configuration files will be stored
+data=$PWD
+
+docker run -d -v $data/conf:/etc/slurm-web \
+              -v /etc/munge:/etc/munge \
+              -v /etc/slurm:/etc/slurm-llnl \
+              -v /etc/passwd:/etc/passwd \
+              -v /etc/group:/etc/group \
+              -p 8081:80 \
+              slurm-web


### PR DESCRIPTION
This PR provides:
* a Dockerfile to build and deploy Slurm-web as a container
* a runscript to run the container
* instructions to build and run the container.