### PR TITLE
Login begin with user's selection when autologin

### DIFF
--- a/dashboard/js/core/login/login.js
+++ b/dashboard/js/core/login/login.js
@@ -59,7 +59,14 @@ define([
           });
       };
 
-      async.mapSeries(window.clusters, loginOnCluster, function(err, result) {
+      var currentClusterIndex = window.clusters.indexOf(config.cluster);
+      var orderedClusters = window.clusters.slice();
+      // copy clusters' list
+      orderedClusters.splice(currentClusterIndex, 1);
+      // remove selected cluster from the list
+      orderedClusters.splice(0,0, config.cluster);
+      // add selected cluster as the first item of the list
+      async.mapSeries(orderedClusters, loginOnCluster, function(err, result) {
         var clusterId = window.clusters.indexOf(config.cluster);
 
         if (err && !userUtils.getUser(config.cluster)) {


### PR DESCRIPTION
With autologin on, the login procedure begins always from the first on
the list whether the user has selected another cluster to start with.
This prevents user from sucessfuly login if one only has access of
clusters which is not on the top of the list due to the modification
for #128. However, certains users will have to redo the login procedure
when trying to reach another cluster for the first time if none of
their granted clusters are on the top of the list. Further discussion
for a more intergrated plan will be needed.