### PR TITLE
quick fix for 3d-view rendering of 8x8 cores..

### DIFF
--- a/dashboard/js/draw/3d-draw.js
+++ b/dashboard/js/draw/3d-draw.js
@@ -349,13 +349,13 @@ define([
       row = tab[0];
       column = tab[1];
 
-      if (row / column === 1) {
-        cpuDimensions = Math.min(width, height);
-        cpuDepth = nodeWidth * config.CPUDEPTH;
-      } else {
+      //if (row / column === 1) {
+      //  cpuDimensions = Math.min(width, height);
+      //  cpuDepth = nodeWidth * config.CPUDEPTH;
+      //} else {
         cpuDimensions = Math.min(height / row, width / column);
         cpuDepth = nodeWidth * config.CPUDEPTH;
-      }
+      //}
 
       factorWidth = column * cpuDimensions;
       factorHeight = row * cpuDimensions;


### PR DESCRIPTION
Solves for now the following issue : 3D view: Node with 64 cores badly rendered  #152