### PR TITLE
Make ACL base on roles

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -348,13 +348,12 @@ Here is an example of a valid configuration file:
   # You can set here an access control list for each view of the dashboard for
   # this cluster.
   # This feature requires authentication to be enabled.
-  # For each view, you can give a list of groups (whose names are prefixed by @)
-  # and logins, to define who can access to this view.
-  # If no ACL is provided for a view, so every authenticated user can access to
+  # For each view, you can give a list of roles to define who
+  # can access to this view.
+  # If no ACL is provided for a view, every authenticated user can access to
   # this view.
-  # i.e. ``jobs = @admin,pierre`` implies that the jobs view will be available
-  # only for every user from the group 'admin', and the user with 'pierre' as
-  # login.
+  # i.e. ``jobs = admin`` implies that the jobs view will be available only
+  # for every user which has role of 'admin'.
   # If you give an empty value for an entry (i.e. ``jobs =``), the corresponding
   # view will not be accessible for anybody.
   #
@@ -362,9 +361,8 @@ Here is an example of a valid configuration file:
   #   'jobs', 'jobsmap', 'partitions', 'reservations', 'qos', 'racks', '3dview',
   #   'gantt', 'topology'
   # ]
-  jobs = @users,@admin
-  gantt = @admin,pierre
-  3dview =
+  jobs = user,admin
+  gantt = admin
 
   [ldap]
   # Configure here settings to connect to your LDAP server.

--- a/rest/auth.py
+++ b/rest/auth.py
@@ -263,14 +263,8 @@ class User(object):
         for xacl in acl:
             view = xacl[0]
             members = xacl[1].split(',')
-            for member in members:
-                if member and member[0] == '@' and self.groups is not None \
-                   and member[1:] in self.groups:
-                    views.remove(view)
-                    break
-                elif member == self.login:
-                    views.remove(view)
-                    break
+            if self.role in members:
+                views.remove(view)
         return list(views)
 
     def get_user_name(self):


### PR DESCRIPTION
The ACL views were based on users and groups which the concept of it is
redundant to the one with "roles" and therefore should be applied by the
latter.

Fix #113