### PR TITLE
Implement trusted_source auth mechanism

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,7 +18,12 @@ It returns an authentication token.
 
 Each method below is a GET method with JSON data. In case when
 authentication is enabled, it must contain a token sent as
-``Authorization`` request header.
+``Authorization`` request header. The second part of the header
+value must be the token:
+
+```
+Authorization: Bearer <TOKEN>
+```
 
 Cluster
 -------

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -46,9 +46,39 @@ The dashboard relies on the backend API, but the reverse is not true. The
 backend API can be used standalone to serve data for other external
 applications.
 
+Authentication & Roles
+----------------------
 
-Authentication mechanism
-------------------------
+A client program (dashboard or API client) will get a token that will authorize
+the client to access data from the Slurm API. There is three role levels:
+
+* ``admin``, all data
+* ``user``, all data concerning the logged-in user
+* ``all``, data publicly accessible
+
+Slurm-web also takes into account of the Private data parameter from
+`Slurm <https://slurm.schedmd.com/slurm.conf.html>`_. So far, only the Jobs
+View and Reservations View in Slurm-web are concerned by Private Data
+parameter. This feature prevents regular users and guests from seeing others'
+jobs or reservations if defined.
+
+The role is determined by the authentication and settings in ``restapi.conf``.
+
+There is three kinds of authentication:
+
+* ``guests``, anonymous access
+* ``user``, username and password matching a real user on the target Slurm
+* ``trusted_sources``, whitelisted client identified by its IP address
+
+
+Guests
+^^^^^^
+
+When the guest mode is enabled, login is not mandatory. A guest user always has the
+``all`` role.
+
+User Authentication
+^^^^^^^^^^^^^^^^^^^
 
 Slurm-web owns its authentication system based on an LDAP server. This feature
 can be enabled by turning the value of the parameter ``authentication`` in the
@@ -92,8 +122,19 @@ You can set in this section:
 - *ugroup* : the LDAP group which the users are members
 - *expiration* : the TTL of the generated token
 
-Slurm-web also takes into account of the Private data parameter from
-`Slurm <https://slurm.schedmd.com/slurm.conf.html>`_. So far, only the Jobs
-View and Reservations View in Slurm-web are concerned by Private Data
-parameter. This feature prevents regular users and guests from seeing others'
-jobs or reservations if defined.
+Trusted Sources
+^^^^^^^^^^^^^^^
+
+When trusted sources are allowed, it is possible to specify an IP address in the
+parameter admin with a ``%`` prefix:
+
+.. code-block:: python
+
+  ...
+
+  [roles]
+  trusted_sources = enabled
+  admin = @adminstrators,%127.0.0.1
+
+  ...
+

--- a/rest/slurmrestapi.py
+++ b/rest/slurmrestapi.py
@@ -92,6 +92,14 @@ def login():
             abort(403, "Guests users are not allowed.")
         except AllUnauthorizedError:
             abort(403, "You do not have any role for this cluster")
+    elif data.get('trusted_source', None) is True:
+        try:
+            source = request.remote_addr
+            user = User.trusted_source(source)
+        except AuthenticationError:
+            abort(403, "Unrecognized source.")
+        except AllUnauthorizedError:
+            abort(403, "No role authorized for this source.")
     else:
         try:
             user = User.user(data['login'],


### PR DESCRIPTION
This patch implements a new (optional) kind of authentication
called `trusted_sources`. This authentication uses the remote address
of the incoming connection. This mechanism is meant to be used by a
remote trusted service to get data from the slurm API.